### PR TITLE
docs: fix typos and add v2.0.0 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ const suiKit = new SuiKit({
 You can use SuiKit to transfer SUI, custom coins, and any objects.
 
 ```typescript
-const recipient1 = '0x123'; // repace with real address
-const recipient2 = '0x456'; // repace with real address
+const recipient1 = '0x123'; // replace with real address
+const recipient2 = '0x456'; // replace with real address
 
 // transfer SUI to single recipient
 await suiKit.transferSui(recipient1, 1000);
@@ -204,7 +204,7 @@ const pkgId =
     paybackCoinB,
     loan,
   ]);
-  // 4. Transfer profits to sender
+  // 5. Transfer profits to sender
   tx.transferObjects([coinB2], sender);
 
   // 5. Execute transaction
@@ -265,6 +265,10 @@ internalTransferSui(suiKit, 0, 1, 1000).then(() => {});
 
 We have a standalone npm package to help you publish and upgrade Move package based on sui-kit.
 
-Please refer to the repository: [sui-package-kit](https://docs.sui.io/devnet/build/install)
+Please refer to the repository: [sui-package-kit](https://github.com/scallop-io/sui-package-kit)
+
+## Migration Guide
+
+If you're upgrading from v1.x to v2.0.0, please refer to the [Migration Guide](./document/migration-guide-v2.md).
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/scallop-io/sui-kit)

--- a/document/README_cn.md
+++ b/document/README_cn.md
@@ -50,7 +50,7 @@ suiKit
 import { SuiKit } from '@scallop-io/sui-kit';
 
 const secretKey = '<密钥>';
-const suiKit = new SuiKit({ secretyKey, networkType: 'devnet' });
+const suiKit = new SuiKit({ secretKey, networkType: 'devnet' });
 suiKit.requestFaucet().then(() => {
   console.log('请求水龙头成功');
 });
@@ -67,7 +67,7 @@ suiKit.requestFaucet().then(() => {
 import { SuiKit } from '@scallop-io/sui-kit';
 
 const secretKey = '<密钥>';
-const suiKit = new SuiKit({ secretyKey, networkType: 'devnet' });
+const suiKit = new SuiKit({ secretKey, networkType: 'devnet' });
 const stakeAmount = 1000;
 const validatorAddress = '0x123';
 suiKit.stakeSui(stakeAmount, validatorAddress).then(() => {
@@ -84,18 +84,18 @@ suiKit.stakeSui(stakeAmount, validatorAddress).then(() => {
  * 这个示例演示如何使用 SuiKit 进行可编程交易
  */
 
-import { SuiKit, TransactionBlock } from '@scallop-io/sui-kit';
+import { SuiKit, SuiTxBlock } from '@scallop-io/sui-kit';
 
 const secretKey = '<密钥>';
 const suiKit = new SuiKit({ secretKey });
 
 // 构建一个交易块以将代币发送到多个账户
-const tx = new TransactionBlock();
+const tx = new SuiTxBlock();
 
 const recipients = ['0x123', '0x456', '0x789'];
 recipients.forEach((recipient) => {
-  const [coin] = tx.splitCoins(tx.gas, [tx.pure(1000)]);
-  tx.transferObjects([coin], tx.pure(recipient));
+  const [coin] = tx.splitCoins(tx.gas, [1000]);
+  tx.transferObjects([coin], recipient);
 });
 
 // 发送交易

--- a/document/migration-guide-v2.md
+++ b/document/migration-guide-v2.md
@@ -1,0 +1,152 @@
+# Migration Guide: v1.x to v2.0.0
+
+This guide helps you migrate your project from sui-kit v1.x to v2.0.0.
+
+## Breaking Changes Overview
+
+### 1. Node.js Version Requirement
+
+**v2.0.0 requires Node.js >= 22**
+
+```bash
+# Check your Node.js version
+node --version
+
+# If needed, upgrade Node.js to v22 or later
+```
+
+### 2. ESM-Only Package
+
+v2.0.0 is now an ESM-only package. CommonJS support has been removed.
+
+**Before (CommonJS):**
+```javascript
+const { SuiKit } = require('@scallop-io/sui-kit');
+```
+
+**After (ESM):**
+```javascript
+import { SuiKit } from '@scallop-io/sui-kit';
+```
+
+If your project uses CommonJS, you need to either:
+- Convert your project to ESM by adding `"type": "module"` to `package.json`
+- Use dynamic imports: `const { SuiKit } = await import('@scallop-io/sui-kit')`
+
+### 3. Dependency Updates
+
+v2.0.0 migrates to the latest Mysten SDK:
+
+| Package | v1.x | v2.0.0 |
+|---------|------|--------|
+| @mysten/sui | ^1.x | ^2.0.0 |
+| @mysten/bcs | ^1.x | ^2.0.0 |
+
+### 4. Client Type Changes
+
+The client type has changed from `SuiClient` to `ClientWithCoreApi`.
+
+**Before:**
+```typescript
+import { SuiClient } from '@mysten/sui/client';
+```
+
+**After:**
+```typescript
+import { ClientWithCoreApi } from '@mysten/sui/client';
+```
+
+### 5. gRPC Support
+
+v2.0.0 adds gRPC client support alongside the existing REST client.
+
+**Using gRPC client:**
+```typescript
+import { SuiKit, SuiGrpcClient } from '@scallop-io/sui-kit';
+
+// The SDK now supports gRPC for improved performance
+const suiKit = new SuiKit({
+  mnemonics: '<your-mnemonics>',
+  networkType: 'mainnet',
+});
+```
+
+### 6. New Exports
+
+v2.0.0 exports additional utilities:
+
+```typescript
+import {
+  SuiKit,
+  SuiTxBlock,
+  getFullnodeUrl,           // New in v2.0.0
+  SimulateTransactionResponse // New in v2.0.0
+} from '@scallop-io/sui-kit';
+```
+
+## Migration Steps
+
+### Step 1: Update Node.js
+
+Ensure you're running Node.js v22 or later.
+
+### Step 2: Update package.json
+
+```json
+{
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "@scallop-io/sui-kit": "^2.0.0"
+  }
+}
+```
+
+### Step 3: Update Import Statements
+
+Convert all `require()` statements to ESM `import` syntax.
+
+### Step 4: Update TypeScript Configuration (if applicable)
+
+```json
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2022"
+  }
+}
+```
+
+### Step 5: Test Your Application
+
+Run your test suite to ensure everything works correctly:
+
+```bash
+npm test
+```
+
+## FAQ
+
+### Q: Can I still use CommonJS?
+
+A: No, v2.0.0 is ESM-only. You must migrate to ESM or use dynamic imports.
+
+### Q: Is the API backward compatible?
+
+A: Yes, the SuiKit API remains largely the same. The main changes are in the module system and underlying dependencies.
+
+### Q: What are the benefits of v2.0.0?
+
+- gRPC support for better performance
+- Latest @mysten/sui SDK features
+- Smaller bundle size with ESM
+- Improved type definitions
+
+## Need Help?
+
+If you encounter issues during migration, please:
+1. Check the [CHANGELOG](../CHANGELOG.md) for detailed changes
+2. Open an issue on [GitHub](https://github.com/scallop-io/sui-kit/issues)


### PR DESCRIPTION
- Fix "repace" typos in README.md
- Fix comment numbering in flashloan example
- Correct sui-package-kit repository link
- Fix secretyKey typos in README_cn.md
- Update Chinese docs to use SuiTxBlock API
- Add migration guide for v1.x to v2.0.0