### PR TITLE
fix: expand moveCall arg types to accept SuiObjectArg and         SuiAmountsArg  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.0.1](https://github.com/scallop-io/sui-kit/compare/v2.0.0...v2.0.1) (2026-03-01)
+
+### Changed
+
+- Include `SuiObjectArg` and `SuiAmountsArg` in `moveCall` argument types ([ba16009](https://github.com/scallop-io/sui-kit/commit/ba16009))
+
 ### [2.0.0](https://github.com/scallop-io/sui-kit/compare/v1.4.3...v2.0.0) (2026-02-05)
 
 ### ⚠ BREAKING CHANGES

--- a/src/libs/suiTxBuilder/index.ts
+++ b/src/libs/suiTxBuilder/index.ts
@@ -166,7 +166,7 @@ export class SuiTxBlock {
    */
   moveCall(
     target: string,
-    args: (SuiTxArg | SuiVecTxArg)[] = [],
+    args: (SuiTxArg | SuiVecTxArg | SuiObjectArg | SuiAmountsArg)[] = [],
     typeArgs: string[] = []
   ) {
     // a regex for pattern `${string}::${string}::${string}`

--- a/src/libs/suiTxBuilder/util.ts
+++ b/src/libs/suiTxBuilder/util.ts
@@ -90,7 +90,12 @@ function isAmountArg(arg: any): arg is bigint | number | string {
 function isMoveVecArg(
   arg: SuiTxArg | SuiVecTxArg | SuiObjectArg | SuiAmountsArg
 ): arg is SuiVecTxArg {
-  if (typeof arg === 'object' && 'vecType' in arg && 'value' in arg) {
+  if (
+    arg !== null &&
+    typeof arg === 'object' &&
+    'vecType' in arg &&
+    'value' in arg
+  ) {
     return true;
   } else if (Array.isArray(arg)) {
     return true;

--- a/src/libs/suiTxBuilder/util.ts
+++ b/src/libs/suiTxBuilder/util.ts
@@ -87,7 +87,9 @@ function isAmountArg(arg: any): arg is bigint | number | string {
  * @param arg The argument to check.
  * @returns boolean.
  */
-function isMoveVecArg(arg: SuiTxArg | SuiVecTxArg): arg is SuiVecTxArg {
+function isMoveVecArg(
+  arg: SuiTxArg | SuiVecTxArg | SuiObjectArg | SuiAmountsArg
+): arg is SuiVecTxArg {
   if (typeof arg === 'object' && 'vecType' in arg && 'value' in arg) {
     return true;
   } else if (Array.isArray(arg)) {
@@ -191,7 +193,7 @@ export function makeVecParam(
  */
 export function convertArgs(
   txBlock: Transaction,
-  args: (SuiTxArg | SuiVecTxArg)[]
+  args: (SuiTxArg | SuiVecTxArg | SuiObjectArg | SuiAmountsArg)[]
 ): TransactionArgument[] {
   return args.map((arg) => {
     if (arg instanceof SerializedBcs || isSerializedBcs(arg)) {
@@ -206,11 +208,10 @@ export function convertArgs(
     }
 
     if (isAmountArg(arg)) {
-      return convertAmounts(txBlock, [arg])[0];
+      return convertAmounts(txBlock, [arg as unknown as SuiAmountsArg])[0];
     }
 
-    // Cast to SuiObjectArg - at this point it should be an object type
-    return convertObjArg(txBlock, arg as unknown as SuiObjectArg);
+    return convertObjArg(txBlock, arg as SuiObjectArg);
   });
 }
 

--- a/src/suiKit.ts
+++ b/src/suiKit.ts
@@ -18,6 +18,7 @@ import type {
   SuiVecTxArg,
   SuiKitReturnType,
   SuiObjectArg,
+  SuiAmountsArg,
   SuiTransactionBlockResponse,
 } from './types/index.js';
 import { normalizeStructTag, SUI_TYPE_ARG } from '@mysten/sui/utils';
@@ -351,7 +352,7 @@ export class SuiKit {
 
   async moveCall(callParams: {
     target: string;
-    arguments?: (SuiTxArg | SuiVecTxArg)[];
+    arguments?: (SuiTxArg | SuiVecTxArg | SuiObjectArg | SuiAmountsArg)[];
     typeArguments?: string[];
     derivePathParams?: DerivePathParams;
   }) {


### PR DESCRIPTION
## Summary                                                     
  `moveCall()` args were too narrow, forcing callers to use `as any[]`.                                                        
Widened `SuiTxBlock.moveCall()`, `convertArgs()`, and `isMoveVecArg()` to accept `SuiObjectArg | SuiAmountsArg` in addition to `SuiTxArg | SuiVecTxArg`.